### PR TITLE
Additional Admin Search Functionality

### DIFF
--- a/app/avo/resources/feed.rb
+++ b/app/avo/resources/feed.rb
@@ -1,9 +1,9 @@
 class Avo::Resources::Feed < Avo::BaseResource
   # self.includes = []
   # self.attachments = []
-  # self.search = {
-  #   query: -> { query.ransack(id_eq: params[:q], m: "or").result(distinct: false) }
-  # }
+  self.search = {
+    query: -> { query.ransack(title_cont: params[:q], m: "or").result(distinct: false) }
+  }
 
   def fields
     field :id, as: :id

--- a/app/avo/resources/minister.rb
+++ b/app/avo/resources/minister.rb
@@ -1,10 +1,10 @@
 class Avo::Resources::Minister < Avo::BaseResource
   # self.includes = []
   # self.attachments = []
-  # self.search = {
-  #   query: -> { query.ransack(id_eq: params[:q], m: "or").result(distinct: false) }
-  # }
-  #
+  self.search = {
+    query: -> { query.ransack(first_name_cont: params[:q], last_name_cont: params[:q], title_cont: params[:q], m: "or").result(distinct: false) }
+  }
+
   self.title = :compound_name
 
   def fields

--- a/app/avo/resources/promise.rb
+++ b/app/avo/resources/promise.rb
@@ -1,9 +1,9 @@
 class Avo::Resources::Promise < Avo::BaseResource
   # self.includes = []
   # self.attachments = []
-  # self.search = {
-  #   query: -> { query.ransack(id_eq: params[:q], m: "or").result(distinct: false) }
-  # }
+  self.search = {
+    query: -> { query.ransack(concise_title_cont: params[:q], m: "or").result(distinct: false) }
+  }
 
   self.title = :concise_title
 

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -3,6 +3,10 @@ class Feed < ApplicationRecord
 
   has_many :entries, dependent: :destroy
 
+  def self.ransackable_attributes(auth_object = nil)
+    [ "title" ]
+  end
+
   def refresh!
     # Implement the logic to refresh the feed data
     response = HTTP.get(url)

--- a/app/models/minister.rb
+++ b/app/models/minister.rb
@@ -3,7 +3,7 @@ class Minister < ApplicationRecord
   belongs_to :department
 
   def compound_name
-    "{title} (#{full_name})"
+    "#{title} (#{full_name})"
   end
 
   def full_name

--- a/app/models/minister.rb
+++ b/app/models/minister.rb
@@ -2,6 +2,10 @@ class Minister < ApplicationRecord
   belongs_to :government
   belongs_to :department
 
+  def self.ransackable_attributes(auth_object = nil)
+    [ "first_name", "last_name", "title" ]
+  end
+
   def compound_name
     "#{title} (#{full_name})"
   end

--- a/app/models/promise.rb
+++ b/app/models/promise.rb
@@ -8,6 +8,10 @@ class Promise < ApplicationRecord
   has_one :lead_department_promise, -> { where(is_lead: true) }, class_name: "DepartmentPromise"
   has_one :lead_department, through: :lead_department_promise, source: :department
 
+  def self.ransackable_attributes(auth_object = nil)
+    [ "concise_title" ]
+  end
+
   def set_last_evidence_date!
     self.last_evidence_date = evidences.where.not(impact: "neutral").map(&:activity).maximum(:published_at)
     self.save!(touch: false)

--- a/test/models/minister_test.rb
+++ b/test/models/minister_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
 class MinisterTest < ActiveSupport::TestCase
-  # test "that each department has a minister" do
-  #   # Ensure that each department has
-  #   assert_equal 0, Department.all.select { |d| d.minister.nil? }.count
-  # end
+  test "that compound_name is correct" do
+    minister = ministers(:finance_minister)
+    assert_equal "Deputy Prime Minister and Minister of Finance (Chrystia Freeland)", minister.compound_name
+  end
 end


### PR DESCRIPTION
Re https://github.com/BuildCanada/OutcomeTrackerAPI/issues/33

- Adds search functionality to Promises, Feeds, and Ministers
- Fixes a typo in the `compound_name` method for Ministers
- Linting fixes

compound_name before:
![Screenshot 2025-07-01 at 10 10 30 AM](https://github.com/user-attachments/assets/bc4aa404-20b9-479d-8a4a-6a84b2009e4e)

compound_name after:
![Screenshot 2025-07-01 at 10 10 17 AM](https://github.com/user-attachments/assets/d6248017-7c03-4d1b-a665-6124b8687bd7)
