### PR TITLE
Search support for Entries, Evidences and Activities

### DIFF
--- a/app/avo/resources/activity.rb
+++ b/app/avo/resources/activity.rb
@@ -1,9 +1,9 @@
 class Avo::Resources::Activity < Avo::BaseResource
   # self.includes = []
   # self.attachments = []
-  # self.search = {
-  #   query: -> { query.ransack(id_eq: params[:q], m: "or").result(distinct: false) }
-  # }
+  self.search = {
+    query: -> { query.ransack(title_cont: params[:q], m: "or").result(distinct: false) }
+  }
 
   def fields
     field :id, as: :id

--- a/app/avo/resources/entry.rb
+++ b/app/avo/resources/entry.rb
@@ -1,9 +1,9 @@
 class Avo::Resources::Entry < Avo::BaseResource
   # self.includes = []
   # self.attachments = []
-  # self.search = {
-  #   query: -> { query.ransack(id_eq: params[:q], m: "or").result(distinct: false) }
-  # }
+  self.search = {
+    query: -> { query.ransack(title_cont: params[:q], summary_cont: params[:q], url_cont: params[:q], m: "or").result(distinct: false) }
+  }
 
   def fields
     field :id, as: :id

--- a/app/avo/resources/evidence.rb
+++ b/app/avo/resources/evidence.rb
@@ -1,9 +1,11 @@
 class Avo::Resources::Evidence < Avo::BaseResource
-  # self.includes = []
+  self.includes = [ :promise, :activity ]
+  self.title = :search_result_title
+  self.description = :search_result_description
   # self.attachments = []
-  # self.search = {
-  #   query: -> { query.ransack(id_eq: params[:q], m: "or").result(distinct: false) }
-  # }
+  self.search = {
+    query: -> { query.ransack(promise_concise_title_cont: params[:q], promise_description_cont: params[:q], promise_promise_id_cont: params[:q], activity_title_cont: params[:q], m: "or").result(distinct: false) }
+  }
 
   def fields
     field :id, as: :id
@@ -21,5 +23,9 @@ class Avo::Resources::Evidence < Avo::BaseResource
     field :link_reason, as: :text
     field :reviewed_by, as: :belongs_to
     field :reviewed_at, as: :date_time
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    [ "promise", "activity" ]
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,4 +4,12 @@ class Activity < ApplicationRecord
 
   has_many :evidences
   has_many :promises, through: :evidences
+
+  def self.ransackable_attributes(auth_object = nil)
+    [ "title" ]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -16,6 +16,10 @@ class Entry < ApplicationRecord
 
   validates :url, presence: true, uniqueness: true
 
+  def self.ransackable_attributes(auth_object = nil)
+    [ "title", "summary", "url" ]
+  end
+
 
   def fetch_data!(inline: false)
     # TODO: make this more robust, this should not be configured globally.

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -4,7 +4,19 @@ class Evidence < ApplicationRecord
   belongs_to :linked_by, class_name: "User", optional: true
   belongs_to :reviewed_by, class_name: "User", optional: true
 
+  def self.ransackable_attributes(auth_object = nil)
+    [ "impact", "impact_reason", "link_reason", "link_type" ]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    [ "promise", "activity" ]
+  end
+
   after_commit do
     self.promise.set_last_evidence_date!
+  end
+
+  def search_result_title
+    "Re: Promise #{promise&.concise_title} - #{activity&.title}"
   end
 end

--- a/app/models/promise.rb
+++ b/app/models/promise.rb
@@ -12,6 +12,10 @@ class Promise < ApplicationRecord
     [ "concise_title" ]
   end
 
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
+
   def set_last_evidence_date!
     self.last_evidence_date = evidences.where.not(impact: "neutral").map(&:activity).maximum(:published_at)
     self.save!(touch: false)

--- a/test/fixtures/activities.yml
+++ b/test/fixtures/activities.yml
@@ -1,0 +1,13 @@
+activity_one:
+  entry: entry_one
+  government: canada
+  title: "Announced a new policy"
+  summary: "To improve public services"
+  published_at: <%= 1.day.ago %>
+
+activity_two:
+  entry: entry_two
+  government: canada
+  title: "Launched a new program"
+  summary: "To support small businesses"
+  published_at: <%= 2.days.ago %>

--- a/test/fixtures/entries.yml
+++ b/test/fixtures/entries.yml
@@ -1,0 +1,21 @@
+entry_one:
+  feed: canada_gazette
+  government: canada
+  title: "First Entry"
+  summary: "This is the summary for the first entry."
+  url: "http://example.com/entry/1"
+  published_at: <%= 2.days.ago %>
+  scraped_at: <%= 1.day.ago %>
+  raw_html: "<html><body><h1>First Entry</h1></body></html>"
+  parsed_markdown: "# First Entry"
+
+entry_two:
+  feed: canada_gazette
+  government: canada
+  title: "Second Entry"
+  summary: "This is the summary for the second entry."
+  url: "http://example.com/entry/2"
+  published_at: <%= 3.days.ago %>
+  scraped_at: <%= 2.days.ago %>
+  raw_html: "<html><body><h1>Second Entry</h1></body></html>"
+  parsed_markdown: "# Second Entry" 

--- a/test/fixtures/evidences.yml
+++ b/test/fixtures/evidences.yml
@@ -1,0 +1,19 @@
+evidence_one:
+  activity: activity_one
+  promise: one
+  impact_magnitude: 5
+  impact: "High"
+  impact_reason: "This is a major policy change."
+  link_type: "Direct"
+  link_reason: "The announcement directly mentions the promise."
+  linked_at: <%= 1.day.ago %>
+
+evidence_two:
+  activity: activity_two
+  promise: two
+  impact_magnitude: 3
+  impact: "Medium"
+  impact_reason: "This program is a step towards fulfilling the promise."
+  link_type: "Indirect"
+  link_reason: "The program aligns with the goals of the promise."
+  linked_at: <%= 2.days.ago %> 


### PR DESCRIPTION
Re https://github.com/BuildCanada/OutcomeTrackerAPI/issues/33

- Adds fixtures for Activities, Entries, and Evidences
- Adds search support for Entries, Evidences, and Activities

Was a bit tricky to come up with good UX for Evidence searching as it's effectively a join table. I came up with a searchable string of "Re: Promise #{policy_title} - #{activity_title}". Happy to tweak if needed.

<img width="728" alt="Screenshot 2025-07-07 at 3 23 20 PM" src="https://github.com/user-attachments/assets/a318cc5b-15f8-4f73-a263-40bcd112539b" />
