### PR TITLE
Run promise job whenever evidence is saved

### DIFF
--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -26,6 +26,7 @@ class Evidence < ApplicationRecord
 
   after_commit do
     self.promise.set_last_evidence_date!
+    self.promise.update_progress!
   end
 
   def search_result_title


### PR DESCRIPTION
Right now we never call update_progress, this changes that so it'll be called whenever a piece of evidence is saved