### PR TITLE
Implement fixes for creating a new entry in the Admin panel

### DIFF
--- a/app/avo/resources/entry.rb
+++ b/app/avo/resources/entry.rb
@@ -21,7 +21,6 @@ class Avo::Resources::Entry < Avo::BaseResource
     field :government, as: :belongs_to
     field :scraped_at, as: :date_time, sortable: true
     field :published_at, as: :date_time, sortable: true
-    field :published_at, as: :date_time, sortable: true
     field :title, as: :text
     field :summary, as: :textarea
     field :evidences, as: :has_many

--- a/app/avo/resources/entry.rb
+++ b/app/avo/resources/entry.rb
@@ -18,6 +18,7 @@ class Avo::Resources::Entry < Avo::BaseResource
     end
 
     field :feed, as: :belongs_to
+    field :government, as: :belongs_to
     field :scraped_at, as: :date_time, sortable: true
     field :published_at, as: :date_time, sortable: true
     field :published_at, as: :date_time, sortable: true
@@ -30,5 +31,14 @@ class Avo::Resources::Entry < Avo::BaseResource
     field :activities, as: :has_many
 
     field :parsed_markdown, as: :markdown
+  end
+
+  def fill_fields
+    super
+
+    # Auto-populate government from the selected feed
+    if record.feed.present? && record.government.blank?
+      record.government = record.feed.government
+    end
   end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -29,7 +29,7 @@ class Entry < ApplicationRecord
       self.skip_reason = "Mailto url not a proper entry"
       self.save!
       return
-    elsif self.published_at < Time.parse("2025-04-28")
+    elsif self.published_at.present? && self.published_at < Time.parse("2025-04-28")
       self.skipped_at = Time.now
       self.skip_reason = "Too old, published before 2025-04-28 (Carney's election)"
       self.save!


### PR DESCRIPTION
# Summary
I fixed the following errors when trying to create a manual entry using the Admin panel -

```
'https://www.canada.ca/en/department-national-defence/maple-leaf/defence/2025/07/message-clerk-privy-council-secretary-cabinet.html' LIMIT 1
  /*action='create',application='OutcomeTrackerApi',controller='entries'*/
  web-1  |   TRANSACTION (0.1ms)  ROLLBACK /*action='create',application='OutcomeTrackerApi',controller='entries'*/
  web-1  | #<ActiveRecord::RecordInvalid: Validation failed: Government must exist>
```
```
"parsed_markdown", "created_at", "updated_at", "activities_extracted_at", "is_index", "parent_id", "skipped_at", "skip_reason") VALUES (1, 'Title', NULL, NULL,
  'https://www.canada.ca/en/department-national-defence/maple-leaf/defence/2025/07/message-clerk-privy-council-secretary-cabinet.html', '2025-07-22 16:00:00', 'Summary', 1, NULL, NULL, NULL, '# Hellow',
  '2025-07-22 22:06:24.676565', '2025-07-22 22:06:24.676565', NULL, TRUE, NULL, NULL, '') RETURNING "id" /*action='create',application='OutcomeTrackerApi',controller='entries'*/
  web-1  |   TRANSACTION (0.5ms)  COMMIT /*action='create',application='OutcomeTrackerApi',controller='entries'*/
  web-1  | Error fetching data for entry 1: undefined method '<' for nil
  web-1  | #<NoMethodError: undefined method '<' for nil>
```
The errors were caused due to the missing value for the required field for Government. I added a method to populate it by with the government value linked to the feed if present and the model relation with `government`.



<img width="700" height="553" alt="Screenshot 2025-07-23 at 10 37 25 PM" src="https://github.com/user-attachments/assets/494b8ac3-5e5c-40f1-bb2f-e065aeb6300e" />

<img width="800" height="681" alt="Screenshot 2025-07-22 at 6 24 36 PM" src="https://github.com/user-attachments/assets/6f794b10-25f5-401b-a320-adba3efaad78" />



Fixes https://github.com/BuildCanada/OutcomeTracker/issues/148


