### PR TITLE
Issue 69 - Saving Promise breaks "What It Means for Canadians"

### DIFF
--- a/app/avo/resources/promise.rb
+++ b/app/avo/resources/promise.rb
@@ -79,7 +79,8 @@ class Avo::Resources::Promise < Avo::BaseResource
     field :text, as: :textarea
     # field :extracted_keywords_concepts, as: :textarea
     # field :intended_impact_and_objectives, as: :textarea
-    field :what_it_means_for_canadians, as: :textarea
+    field :what_it_means_for_canadians_for_avo, as: :textarea,
+          name: "What it means for Canadians"
     # field :linked_evidence_ids, as: :textarea
     # field :relevant_departments, as: :textarea
     # field :commitment_history_rationale, as: :code

--- a/app/models/promise.rb
+++ b/app/models/promise.rb
@@ -52,6 +52,28 @@ class Promise < ApplicationRecord
     self.save!
   end
 
+  # Virtual attribute for Avo admin interface
+  def what_it_means_for_canadians_for_avo
+    what_it_means_for_canadians&.inspect || "[]"
+  end
+
+  # Handle array format for Avo admin interface
+  def what_it_means_for_canadians_for_avo=(value)
+    if value.is_a?(String)
+      if value.strip.start_with?("[") && value.strip.end_with?("]")
+        begin
+          parsed = JSON.parse(value)
+          self.what_it_means_for_canadians = parsed if parsed.is_a?(Array)
+        rescue JSON::ParserError => e
+          Rails.logger.warn("Failed to parse array format: #{e.message}")
+        end
+      else
+        Rails.logger.warn("Expected array format but got: #{value}")
+      end
+    else
+      self.what_it_means_for_canadians = value
+    end
+  end
 
   def self.client_fields
     [

--- a/app/models/promise.rb
+++ b/app/models/promise.rb
@@ -8,6 +8,8 @@ class Promise < ApplicationRecord
   has_one :lead_department_promise, -> { where(is_lead: true) }, class_name: "DepartmentPromise"
   has_one :lead_department, through: :lead_department_promise, source: :department
 
+  validate :validate_what_it_means_for_canadians_for_avo
+
   def self.ransackable_attributes(auth_object = nil)
     [ "concise_title" ]
   end
@@ -54,24 +56,43 @@ class Promise < ApplicationRecord
 
   # Virtual attribute for Avo admin interface
   def what_it_means_for_canadians_for_avo
-    what_it_means_for_canadians&.inspect || "[]"
+    JSON.generate(what_it_means_for_canadians || [])
   end
 
   # Handle array format for Avo admin interface
   def what_it_means_for_canadians_for_avo=(value)
+    error_message = "Must be a valid array format"
     if value.is_a?(String)
-      if value.strip.start_with?("[") && value.strip.end_with?("]")
+      stripped = value.strip
+      if stripped.empty?
+        self.what_it_means_for_canadians = []
+        @what_it_means_for_canadians_for_avo_error = nil
+        return
+      end
+      if stripped.start_with?("[") && stripped.end_with?("]")
         begin
-          parsed = JSON.parse(value)
-          self.what_it_means_for_canadians = parsed if parsed.is_a?(Array)
-        rescue JSON::ParserError => e
-          Rails.logger.warn("Failed to parse array format: #{e.message}")
+          parsed = JSON.parse(stripped)
+          if parsed.is_a?(Array)
+            self.what_it_means_for_canadians = parsed
+            @what_it_means_for_canadians_for_avo_error = nil
+          else
+            @what_it_means_for_canadians_for_avo_error = error_message
+          end
+        rescue JSON::ParserError
+          @what_it_means_for_canadians_for_avo_error = error_message
         end
       else
-        Rails.logger.warn("Expected array format but got: #{value}")
+        @what_it_means_for_canadians_for_avo_error = error_message
       end
     else
       self.what_it_means_for_canadians = value
+      @what_it_means_for_canadians_for_avo_error = nil
+    end
+  end
+
+  private def validate_what_it_means_for_canadians_for_avo
+    if defined?(@what_it_means_for_canadians_for_avo_error) && @what_it_means_for_canadians_for_avo_error.present?
+      errors.add(:what_it_means_for_canadians_for_avo, @what_it_means_for_canadians_for_avo_error)
     end
   end
 


### PR DESCRIPTION
See the comment on the issue for the full details: [https://github.com/BuildCanada/OutcomeTrackerAPI/issues/69#issuecomment-3316111384](https://github.com/BuildCanada/OutcomeTrackerAPI/issues/69#issuecomment-3316111384)

I adjusted the parsing algo to handle empty strings and setting avo error. The avo field has validation to show the error on the save in the admin.

Feel free to adjust or correct any parts of this fix.