### PR TITLE
Add production docker-compose with separate GoodJob worker

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,45 @@
+services:
+  web:
+    build: .
+    ports:
+      - "${PORT:-4000}:3000"
+    environment:
+      - RAILS_ENV=production
+      - RAILS_MASTER_KEY
+      - DATABASE_URL
+      - HOST
+      - RAILS_LOG_LEVEL
+      - RAILS_MAX_THREADS
+      - GOOD_JOB_EXECUTION_MODE=external
+      - SMTP_USER_NAME
+      - SMTP_PASSWORD
+      - SMTP_ADDRESS
+      - GEMINI_API_KEY
+      - APPSIGNAL_PUSH_API_KEY
+    depends_on:
+      worker:
+        condition: service_started
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/up"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  worker:
+    build: .
+    command: bundle exec good_job start
+    environment:
+      - RAILS_ENV=production
+      - RAILS_MASTER_KEY
+      - DATABASE_URL
+      - HOST
+      - RAILS_LOG_LEVEL
+      - GOOD_JOB_EXECUTION_MODE=external
+      - SMTP_USER_NAME
+      - SMTP_PASSWORD
+      - SMTP_ADDRESS
+      - GEMINI_API_KEY
+      - APPSIGNAL_PUSH_API_KEY
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Adds `docker-compose.prod.yml` with separate `web` and `worker` services sharing the same image
- Worker runs `bundle exec good_job start` as its own container, handling all background jobs and cron scheduling
- Uses `GOOD_JOB_EXECUTION_MODE=external` env var so the web process no longer runs jobs inline

## Test plan
- [ ] Build image and run `docker compose -f docker-compose.prod.yml up`
- [ ] Verify web container serves requests and does not execute jobs
- [ ] Verify worker container picks up and executes enqueued jobs
- [ ] Verify cron jobs fire on schedule from the worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)