### PR TITLE
Add production docker-compose with separate GoodJob worker

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,6 +16,7 @@ services:
       - SMTP_ADDRESS
       - GEMINI_API_KEY
       - APPSIGNAL_PUSH_API_KEY
+      - CLAUDE_CODE_OAUTH_TOKEN
     depends_on:
       worker:
         condition: service_started
@@ -42,4 +43,5 @@ services:
       - SMTP_ADDRESS
       - GEMINI_API_KEY
       - APPSIGNAL_PUSH_API_KEY
+      - CLAUDE_CODE_OAUTH_TOKEN
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Adds `docker-compose.prod.yml` with separate `web` and `worker` services for GoodJob external execution mode
- Passes `CLAUDE_CODE_OAUTH_TOKEN` env var to both containers

## Test plan
- [ ] Deploy with `docker compose -f docker-compose.prod.yml up` and verify both services start
- [ ] Confirm GoodJob worker processes jobs independently from the web server
- [ ] Verify `CLAUDE_CODE_OAUTH_TOKEN` is available inside both containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)